### PR TITLE
Networking startup process

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -112,20 +112,5 @@ if ! shopt -oq posix; then
   fi
 fi
 
-
-### Rover brain startup stuff!
-
-if git -C ~/Scheduler pull; then
-	echo "Scheduler repo pulled successfully."
-else
-	echo "Error pulling Scheduler repo." 1>&2
-fi
-if git -C ~/wifistuff pull; then
-	echo "RaspberryPiSetup repo pulled successfully."
-else
-	echo "Error pulling RaspberryPiSetup repo." 1>&2
-fi
-
-#python3 ~/Scheduler/scheduler_start.py
-python3 ~/Scheduler/scheduler_start_arm.py
-
+# Source the robot setup script. Runs everytime at startup, and everytime a new terminal is opened
+source .bashrc_robot_setup

--- a/.bashrc_robot_setup
+++ b/.bashrc_robot_setup
@@ -5,27 +5,29 @@
 declare -r scheduler_repo_link="https://github.com/Uvic-Robotics-Club/Scheduler.git"
 declare -r rpi_setup_repo_link="https://github.com/Uvic-Robotics-Club/RaspberryPiSetup.git"
 
-if [! -d "./Scheduler/"]
+if [ ! -d "./Scheduler/" ]
 then
    scheduler_pull_command="git clone ${scheduler_repo_link}"
 else 
    scheduler_pull_command="git -C ./Scheduler pull"
 fi 
 
-if ${scheduler_pull_command} then
+if ${scheduler_pull_command} 
+then
 	echo "Scheduler repo pulled successfully."
 else
 	echo "Error pulling Scheduler repo." 1>&2
 fi  
 
-if [! -d "./RaspberryPiSetup"]
+if [ ! -d "./RaspberryPiSetup" ]
 then
     rpi_setup_pull_command="git clone ${rpi_setup_repo_link}" 
 else 
     rpi_setup_pull_command="git -C ./RaspberryPiSetup pull"
 fi 
 
-if git clone ${rpi_setup_repo_link}; then
+if ${rpi_setup_pull_command} 
+then
 	echo "RaspberryPiSetup repo pulled successfully."
 else
 	echo "Error pulling RaspberryPiSetup repo." 1>&2

--- a/.bashrc_robot_setup
+++ b/.bashrc_robot_setup
@@ -5,11 +5,26 @@
 declare -r scheduler_repo_link="https://github.com/Uvic-Robotics-Club/Scheduler.git"
 declare -r rpi_setup_repo_link="https://github.com/Uvic-Robotics-Club/RaspberryPiSetup.git"
 
-if git clone ${scheduler_repo_link}; then
+if [! -d "./Scheduler/"]
+then
+   scheduler_pull_command="git clone ${scheduler_repo_link}"
+else 
+   scheduler_pull_command="git -C ./Scheduler pull"
+fi 
+
+if ${scheduler_pull_command} then
 	echo "Scheduler repo pulled successfully."
 else
 	echo "Error pulling Scheduler repo." 1>&2
-fi
+fi  
+
+if [! -d "./RaspberryPiSetup"]
+then
+    rpi_setup_pull_command="git clone ${rpi_setup_repo_link}" 
+else 
+    rpi_setup_pull_command="git -C ./RaspberryPiSetup pull"
+fi 
+
 if git clone ${rpi_setup_repo_link}; then
 	echo "RaspberryPiSetup repo pulled successfully."
 else

--- a/.bashrc_robot_setup
+++ b/.bashrc_robot_setup
@@ -1,0 +1,32 @@
+### Script that helps setup environment for robot operation. Located in separate file from .bashrc as this 
+### increases usability in terms of sourcing this file elsewhere when needed
+
+
+### Ask the user if WiFi needs to be setup. As opposed to assuming yes everytime, which 
+### will cause a continuous system reboot 
+
+while true; do 
+	read -p "Do you wish to configure Wifi settings (Y/[else])?" yn
+	case $yn in 
+	    [Y]*  ) /bin/bash wifistuff/wifisetup.sh; sudo reboot;	
+	esac 
+	break
+done 
+
+echo "Completed WiFi settings setup"
+
+### Rover brain startup stuff!
+
+if git -C ~/Scheduler pull; then
+	echo "Scheduler repo pulled successfully."
+else
+	echo "Error pulling Scheduler repo." 1>&2
+fi
+if git -C ~/wifistuff pull; then
+	echo "RaspberryPiSetup repo pulled successfully."
+else
+	echo "Error pulling RaspberryPiSetup repo." 1>&2
+fi
+
+#python3 ~/Scheduler/scheduler_start.py
+python3 ~/Scheduler/scheduler_start_arm.py

--- a/.bashrc_robot_setup
+++ b/.bashrc_robot_setup
@@ -5,6 +5,7 @@
 declare -r scheduler_repo_link="https://github.com/Uvic-Robotics-Club/Scheduler.git"
 declare -r rpi_setup_repo_link="https://github.com/Uvic-Robotics-Club/RaspberryPiSetup.git"
 
+# Determine command to run if the Scheduler/ directory exists or not
 if [ ! -d "./Scheduler/" ]
 then
    scheduler_pull_command="git clone ${scheduler_repo_link}"
@@ -12,6 +13,7 @@ else
    scheduler_pull_command="git -C ./Scheduler pull"
 fi 
 
+# Run git command
 if ${scheduler_pull_command} 
 then
 	echo "Scheduler repo pulled successfully."
@@ -19,6 +21,7 @@ else
 	echo "Error pulling Scheduler repo." 1>&2
 fi  
 
+# Determine command to run if the RaspberryPiSetup/ directory exists or not
 if [ ! -d "./RaspberryPiSetup" ]
 then
     rpi_setup_pull_command="git clone ${rpi_setup_repo_link}" 
@@ -26,6 +29,7 @@ else
     rpi_setup_pull_command="git -C ./RaspberryPiSetup pull"
 fi 
 
+# Run git command
 if ${rpi_setup_pull_command} 
 then
 	echo "RaspberryPiSetup repo pulled successfully."

--- a/.bashrc_robot_setup
+++ b/.bashrc_robot_setup
@@ -1,28 +1,16 @@
 ### Script that helps setup environment for robot operation. Located in separate file from .bashrc as this 
 ### increases usability in terms of sourcing this file elsewhere when needed
-
-
-### Ask the user if WiFi needs to be setup. As opposed to assuming yes everytime, which 
-### will cause a continuous system reboot 
-
-while true; do 
-	read -p "Do you wish to configure Wifi settings (Y/[else])?" yn
-	case $yn in 
-	    [Y]*  ) /bin/bash wifistuff/wifisetup.sh; sudo reboot;	
-	esac 
-	break
-done 
-
-echo "Completed WiFi settings setup"
-
 ### Rover brain startup stuff!
 
-if git -C ~/Scheduler pull; then
+declare -r scheduler_repo_link="https://github.com/Uvic-Robotics-Club/Scheduler.git"
+declare -r rpi_setup_repo_link="https://github.com/Uvic-Robotics-Club/RaspberryPiSetup.git"
+
+if git clone ${scheduler_repo_link}; then
 	echo "Scheduler repo pulled successfully."
 else
 	echo "Error pulling Scheduler repo." 1>&2
 fi
-if git -C ~/wifistuff pull; then
+if git clone ${rpi_setup_repo_link}; then
 	echo "RaspberryPiSetup repo pulled successfully."
 else
 	echo "Error pulling RaspberryPiSetup repo." 1>&2

--- a/readme_wifi.txt
+++ b/readme_wifi.txt
@@ -16,3 +16,12 @@ network = {
   key_mgmt=NONE
   id_str="NetworkNickname"
 }
+
+NOTE: After updating the network settings as described above, it is likely that 
+when `wpa_supplicant` is run after saving those changes, an error will occur that 
+prompts you to delete certain files, or modify a file so that changing networks 
+is possible. 
+
+If that happens, follow the instructions. Regardless, once the Pi has started up 
+once successfully on a newly configured network, the errors will not persist and 
+the Pi can be restarted without any network issues.

--- a/wifisetup.sh
+++ b/wifisetup.sh
@@ -1,1 +1,2 @@
 sudo nano /etc/wpa_supplicant/wpa_supplicant.conf
+wpa_supplicant -B -i wlan0 -c /etc/wpa_supplicant/wpa_supplicant.conf

--- a/wifisetup_realprogrammersusevim.sh
+++ b/wifisetup_realprogrammersusevim.sh
@@ -1,1 +1,2 @@
 sudo vim /etc/wpa_supplicant/wpa_supplicant.conf
+wpa_supplicant -B -i wlan0 -c /etc/wpa_supplicant/wpa_supplicant.conf


### PR DESCRIPTION
The changes in this PR consolidate the startup process for the RPi in terms of networking. An existing issue was that if the WiFi settings are not applied, the startup process would fail. The changes in this PR are as follows:

1. In `wifisetup.sh` and `wifisetup_realprogrammersusevim.sh` scripts, the `wpa_supplicant` command is added to apply the new WiFi settings. A reboot is required for the new settings to actually apply.
2. De-coupled the given `.bashrc` code with our robot script in `.bashrc_robot_setup`. As noted in the script it allows us to soruce the file when necessary in a faster manner.
3. `.bashrc_robot_setup` updates the repositories depending on whether or not the directories are present. This allows for first-time setup.

**Note**: Given the WiFi is functioning, the startup process is still automatic